### PR TITLE
Improve scanner accuracy

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47",
-        "version" : "1.21.2"
+        "revision" : "7dc119c7edf3c23f52638faadb89182861dee853",
+        "version" : "1.28.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alfianlosari/ChatGPTSwift.git",
       "state" : {
-        "revision" : "5d10da6f680a217ab458bea2402c41982599d525",
-        "version" : "2.3.2"
+        "revision" : "79395f6f062bf2d41c53e1cfb8e915241f3c568f",
+        "version" : "2.5.0"
       }
     },
     {
@@ -55,12 +55,21 @@
       }
     },
     {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "1625f271afb04375bf48737a5572613248d0e7a0",
+        "version" : "1.4.0"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "1ddbea1ee34354a6a2532c60f98501c35ae8edfa",
-        "version" : "1.2.0"
+        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version" : "1.4.0"
       }
     },
     {
@@ -77,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
-        "version" : "2.67.0"
+        "revision" : "154706efd36d8d8a7d030eea9bcbeca56a947c62",
+        "version" : "2.86.1"
       }
     },
     {
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a3b640d7dc567225db7c94386a6e71aded1bfa63",
-        "version" : "1.22.0"
+        "revision" : "f1f6f772198bee35d99dd145f1513d8581a54f2c",
+        "version" : "1.26.0"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "8d8eb609929aee75336a0a3d2417280786265868",
-        "version" : "1.32.0"
+        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
+        "version" : "1.38.0"
       }
     },
     {
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "2b09805797f21c380f7dc9bedaab3157c5508efb",
-        "version" : "2.27.0"
+        "revision" : "b2b043a8810ab6d51b3ff4df17f057d87ef1ec7c",
+        "version" : "2.34.1"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
-        "version" : "1.21.0"
+        "revision" : "e645014baea2ec1c2db564410c51a656cf47c923",
+        "version" : "1.25.1"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-openapi-async-http-client",
       "state" : {
-        "revision" : "abfe558a66992ef1e896a577010f957915f30591",
-        "version" : "1.0.0"
+        "revision" : "915aeff168625b0f88a5810ee7ab8e9c00af671b",
+        "version" : "1.1.0"
       }
     },
     {
@@ -140,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "9a8291fa2f90cc7296f2393a99bb4824ee34f869",
-        "version" : "1.4.0"
+        "revision" : "7722cf8eac05c1f1b5b05895b04cfcc29576d9be",
+        "version" : "1.8.3"
       }
     },
     {
@@ -149,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "6efbfda5276bbbc8b4fec5d744f0ecd8c784eb47",
-        "version" : "1.0.1"
+        "revision" : "6fac6f7c428d5feea2639b5f5c8b06ddfb79434b",
+        "version" : "1.1.0"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
-        "version" : "1.3.1"
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["AIReceiptScanner"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/alfianlosari/ChatGPTSwift.git", from: "2.3.2")
+        .package(url: "https://github.com/alfianlosari/ChatGPTSwift.git", from: "2.5.0")
     ],
     targets: [
         .target(

--- a/Sources/AIReceiptScanner/AIReceiptScanner.swift
+++ b/Sources/AIReceiptScanner/AIReceiptScanner.swift
@@ -21,8 +21,8 @@ Carefully analyze this receipt image and extract ALL items with their exact quan
 
 IMPORTANT RULES:
 1. Extract EVERY item shown on the receipt - do not skip any items
-2. Look for quantity indicators like "2 x", "QTY 2", numbers before item names, or weight (kg/lb)
-3. For weighted items (e.g., "2.00 e/kg"), the first number is the quantity in kg
+2. Look for quantity indicators like "2 x", "QTY 2", numbers before item names
+3. For each item line use line total price. For example if there's line "4 bottles - coca-cola - $1/bottle - $4" - you have to use $4 for price. 
 4. Match the exact total amount shown on the receipt
 
 Use this exact JSON format:
@@ -39,7 +39,7 @@ Use this exact JSON format:
     "items": [
         {
             "name": "exact name of the item as shown. string type",
-            "price": "unit price or line total (check receipt format). number type",
+            "price": "line total (NOT UNIT PRICE!). number type",
             "quantity": "exact quantity purchased (look for multipliers, weights, or quantity indicators). number type"
             "category": "enum of \(Category.allCases.map {$0.rawValue}.split(separator: ",")). if not sure, use Utilities as fallback value"
         }
@@ -68,7 +68,7 @@ Double-check: The sum of all items should approximately match the subtotal/total
     }
     
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-    public func scanImage(_ image: ReceiptImage, targetSize: CGSize = .init(width: 1024, height: 1024), compressionQuality: CGFloat = 0.8, model: ChatGPTModel = .gpt_hyphen_4_period_1_hyphen_mini, temperature: Double = 1.0) async throws -> Receipt {
+    public func scanImage(_ image: ReceiptImage, targetSize: CGSize = .init(width: 1024, height: 1024), compressionQuality: CGFloat = 0.8, model: ChatGPTModel = .gpt_hyphen_4_period_1_hyphen_mini, temperature: Double = 0.3) async throws -> Receipt {
         let imageData: Data
         #if os(macOS)
         imageData = image.scaleToFit(targetSize: targetSize)!.scaledJPGData(compressionQuality: compressionQuality)!
@@ -79,7 +79,7 @@ Double-check: The sum of all items should approximately match the subtotal/total
     }
     #endif
     
-    public func scanImageData(_ data: Data, model: ChatGPTModel = .gpt_hyphen_4_period_1_hyphen_mini, temperature: Double = 1.0) async throws -> Receipt {
+    public func scanImageData(_ data: Data, model: ChatGPTModel = .gpt_hyphen_4_period_1_hyphen_mini, temperature: Double = 0.3) async throws -> Receipt {
         do {
             let response = try await api.sendMessage(
                 text: promptText,


### PR DESCRIPTION
I had issues with recognizing receipts:

- The date was sometimes recognized incorrectly as a random date in 2023, instead of the correct 2025.
- Items were missing from long receipts.

**Changes in the PR:**
**1. ChatGPTSwift SDK Update**
- Updated ChatGPTSwift to the latest 2.5.0

**2. Enhanced scan image quality**
- Increased resolution from 512x512 to 1024x1024 pixels
- Improved JPEG compression quality from 0.5 to 0.8

**3. Improved prompt**
- Added explicit instructions to extract ALL items without skipping
- Clear guidance for quantity detection: "2 x", "QTY", weights (kg/lb)
- Specific handling for weighted items (e.g., "2.00 e/kg")
- Validation rule: sum of items should match receipt total

**4. Model Optimization**
- Changed default model from gpt-4o to gpt-4.1-mini - it recognizes much better, I never get errors using it. 

**4. Set lower temperature**
- Set default temperature to 0.3 for more deterministic behavior.
